### PR TITLE
Add no_std support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,8 +19,20 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: x86_64-unknown-none
+
+    - uses: cargo-bins/cargo-binstall@main
+
+    - name: Install cargo-no-std
+      run: cargo binstall --no-confirm --force cargo-no-std
+
     - name: Check
       run: cargo check --verbose --all-features --all-targets
+
+    - name: Check no_std
+      run: cargo no-std --no-default-features --features libm
 
     - name: Build
       run: cargo build --verbose --all-features --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["std"]
 dev = []
+libm = ["num-traits/libm"]
+std = ["num-traits/std"]
 
 [lib]
 bench = false
@@ -23,7 +26,7 @@ harness = false
 required-features = ["dev"]
 
 [dependencies]
-num-traits = "0.2.19"
+num-traits = { version = "0.2.19", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ Both types are generic over a parameter `T: num_traits::float::Float`, which is 
 They support addition and subtraction (also with assignment) of `T` and `&T`.
 The estimated total sum (of type `T`) can be retrieved with a method called `total()`.
 
-Both types also implement [`std::iter::Sum`], which means that iterators of floating-point numbers can be conveniently summed.
+Both types also implement [`core::iter::Sum`], which means that iterators of floating-point numbers can be conveniently summed.
 
 # Examples
 
@@ -76,10 +76,11 @@ Don't be fooled by the Kahan-Babuška result being `0.0`: from the `f64` perspec
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(uncommon_codepoints, mixed_script_confusables)]
+#![no_std]
 
+use core::iter::Sum;
+use core::ops::{Add, AddAssign, Sub, SubAssign};
 use num_traits::float::Float;
-use std::iter::Sum;
-use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 /// `2Sum` algorithm, see <https://en.wikipedia.org/wiki/2Sum>.
 ///
@@ -141,11 +142,11 @@ pub fn fast_two_sum<T: Float>(a: T, b: T) -> (T, T) {
 /// assert_eq!(sum.total(), 0.0);
 /// ```
 ///
-/// In addition, [`KahanBabuska`] implements the [`std::iter::Sum`](#impl-Sum<V>-for-KahanBabuska<T>) trait, which means that an iterator of floating-point numbers can be summed either by calling [`KahanBabuska::sum()`] directly
+/// In addition, [`KahanBabuska`] implements the [`core::iter::Sum`](#impl-Sum<V>-for-KahanBabuska<T>) trait, which means that an iterator of floating-point numbers can be summed either by calling [`KahanBabuska::sum()`] directly
 ///
 /// ```
 /// # use compensated_summation::KahanBabuska;
-/// use std::iter::Sum; // remember to import the trait
+/// use core::iter::Sum; // remember to import the trait
 /// let iter = [0.1, 0.2, -0.3].iter();
 /// assert_eq!(KahanBabuska::sum(iter).total(), 0.0);
 /// ```
@@ -282,11 +283,11 @@ where
 /// assert_eq!(sum.total(), f64::EPSILON / 8.0);
 /// ```
 ///
-/// In addition, [`KahanBabuskaNeumaier`] implements the [`std::iter::Sum`](#impl-Sum<V>-for-KahanBabuskaNeumaier<T>) trait, which means that an iterator of floating-point numbers can be summed either by calling [`KahanBabuskaNeumaier::sum()`] directly
+/// In addition, [`KahanBabuskaNeumaier`] implements the [`core::iter::Sum`](#impl-Sum<V>-for-KahanBabuskaNeumaier<T>) trait, which means that an iterator of floating-point numbers can be summed either by calling [`KahanBabuskaNeumaier::sum()`] directly
 ///
 /// ```
 /// # use compensated_summation::KahanBabuskaNeumaier;
-/// use std::iter::Sum; // remember to import the trait
+/// use core::iter::Sum; // remember to import the trait
 /// let iter = [0.1, 0.2, -0.3].iter();
 /// assert_eq!(KahanBabuskaNeumaier::sum(iter).total(), f64::EPSILON / 8.0);
 /// ```
@@ -539,6 +540,10 @@ mod tests {
 
     #[test]
     fn test_correctness() {
+        extern crate std;
+
+        use std::vec::Vec;
+
         use rand::prelude::*;
         use rand_distr::LogNormal;
         use rand_xoshiro::Xoshiro256PlusPlus;


### PR DESCRIPTION
The Float trait is only available when num-traits has the std or libm features enabled. As such, it makes sense to expose these features for this crate as well.